### PR TITLE
Rename b3 indicator to b11fpi

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ Custom NinjaTrader indicators updated for version 8.1.5.
 * `b2` – zone/vwap touch and limit order alerts
 * `b41_mintrade` – footprint/absorption indicator with minimum trade filter
 * `b4_bigorder` – marks large orders on the chart
+* `b11fpi` – footprint imbalance zones indicator

--- a/aaa/b11fpi.cs
+++ b/aaa/b11fpi.cs
@@ -10,14 +10,13 @@ using NinjaTrader.NinjaScript;
 using NinjaTrader.NinjaScript.Indicators;
 using NinjaTrader.NinjaScript.DrawingTools;
 using SharpDX;
-using SharpDX.Direct2D1;
 #endregion
 
-// b3.cs - Footprint/absorption indicator for NinjaTrader 8.1.5.1
+// b11fpi.cs - Footprint/imbalance indicator for NinjaTrader 8.1.5.1
 
 namespace NinjaTrader.NinjaScript.Indicators
 {
-    public class b3 : Indicator
+    public class b11fpi : Indicator
     {
         public readonly struct LevelStats
         {
@@ -108,7 +107,7 @@ namespace NinjaTrader.NinjaScript.Indicators
 
         [NinjaScriptProperty]
         [Display(Name = "Rect Fill", Order = 5, GroupName = "Imbalance")]
-        public Brush RectFill { get; set; } = Brushes.Brown;
+        public Brush RectFill { get; set; } = new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromArgb(77, 165, 42, 42));
 
         [NinjaScriptProperty]
         [Display(Name = "Rect Border Ask", Order = 6, GroupName = "Imbalance")]
@@ -122,9 +121,9 @@ namespace NinjaTrader.NinjaScript.Indicators
         [Display(Name = "Session Template", Order = 8, GroupName = "Imbalance")]
         public string SessionName { get; set; } = "CME US Index Futures ETH";
 
-        private SolidColorBrush brushText;
-        private SolidColorBrush brushBorder;
-        private SolidColorBrush brushImbalance;
+        private SharpDX.Direct2D1.SolidColorBrush brushText;
+        private SharpDX.Direct2D1.SolidColorBrush brushBorder;
+        private SharpDX.Direct2D1.SolidColorBrush brushImbalance;
         private SharpDX.DirectWrite.TextFormat textFormat;
         private SharpDX.DirectWrite.TextFormat bottomTextFormat;
 
@@ -132,8 +131,8 @@ namespace NinjaTrader.NinjaScript.Indicators
         {
             if (State == State.SetDefaults)
             {
-                Name                    = "b3";
-                Description             = "Footprint/absorption indicator";
+                Name                    = "b11fpi";
+                Description             = "Footprint/imbalance indicator";
                 Calculate               = Calculate.OnPriceChange;
                 IsOverlay               = true;
                 DrawOnPricePanel        = false;
@@ -184,9 +183,9 @@ namespace NinjaTrader.NinjaScript.Indicators
             if (RenderTarget == null)
                 return;
 
-            brushText  = new SolidColorBrush(RenderTarget, new Color4(0f, 0f, 0f, 1f));
-            brushBorder = new SolidColorBrush(RenderTarget, new Color4(0f, 0f, 0f, 1f));
-            brushImbalance = new SolidColorBrush(RenderTarget, new Color4(0f, 0f, 1f, 1f));
+            brushText  = new SharpDX.Direct2D1.SolidColorBrush(RenderTarget, new Color4(0f, 0f, 0f, 1f));
+            brushBorder = new SharpDX.Direct2D1.SolidColorBrush(RenderTarget, new Color4(0f, 0f, 0f, 1f));
+            brushImbalance = new SharpDX.Direct2D1.SolidColorBrush(RenderTarget, new Color4(0f, 0f, 1f, 1f));
         }
 
         public override void OnRenderTargetChanged()
@@ -501,19 +500,19 @@ namespace NinjaTrader.NinjaScript.Indicators
 {
     public partial class Indicator : NinjaTrader.Gui.NinjaScript.IndicatorRenderBase
     {
-        private b3[] cacheb3;
-        public b3 b3(float tamanoLetraFootprint)
+        private b11fpi[] cacheb11fpi;
+        public b11fpi b11fpi(float tamanoLetraFootprint)
         {
-            return b3(Input, tamanoLetraFootprint);
+            return b11fpi(Input, tamanoLetraFootprint);
         }
 
-        public b3 b3(ISeries<double> input, float tamanoLetraFootprint)
+        public b11fpi b11fpi(ISeries<double> input, float tamanoLetraFootprint)
         {
-            if (cacheb3 != null)
-                for (int idx = 0; idx < cacheb3.Length; idx++)
-                    if (cacheb3[idx] != null && cacheb3[idx].TamanoLetraFootprint == tamanoLetraFootprint && cacheb3[idx].EqualsInput(input))
-                        return cacheb3[idx];
-            return CacheIndicator<b3>(new b3(){ TamanoLetraFootprint = tamanoLetraFootprint }, input, ref cacheb3);
+            if (cacheb11fpi != null)
+                for (int idx = 0; idx < cacheb11fpi.Length; idx++)
+                    if (cacheb11fpi[idx] != null && cacheb11fpi[idx].TamanoLetraFootprint == tamanoLetraFootprint && cacheb11fpi[idx].EqualsInput(input))
+                        return cacheb11fpi[idx];
+            return CacheIndicator<b11fpi>(new b11fpi(){ TamanoLetraFootprint = tamanoLetraFootprint }, input, ref cacheb11fpi);
         }
     }
 }


### PR DESCRIPTION
## Summary
- rename indicator to `b11fpi`
- mark new indicator in README
- default rectangle fill uses 30% opacity
- resolve ambiguous brush references

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68655051bd20832cbe19bf58f281de26