### PR TITLE
Fix avp ProfileMode references and volumetric bounds check

### DIFF
--- a/aaa/avp
+++ b/aaa/avp
@@ -31,18 +31,17 @@ using NinjaTrader.NinjaScript.DrawingTools;
 
 namespace NinjaTrader.NinjaScript.Indicators
 {
-    // ---------------------------
-    // Tipos
-    // ---------------------------
-    public enum ProfileMode
-    {
-        RollingMinutes = 0,
-        Session        = 1,
-        Weekly         = 2
-    }
-
     public class avp : Indicator
     {
+        // ---------------------------
+        // Tipos
+        // ---------------------------
+        public enum ProfileMode
+        {
+            RollingMinutes = 0,
+            Session        = 1,
+            Weekly         = 2
+        }
 
         private class BarContribution
         {
@@ -850,12 +849,12 @@ namespace NinjaTrader.NinjaScript.Indicators
     {
         private avp[] cacheavp;
 
-        public avp avp(global::NinjaTrader.NinjaScript.Indicators.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
+        public avp avp(global::NinjaTrader.NinjaScript.Indicators.avp.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
         {
             return avp(Input, mode, windowMinutes, volumetricTimeFrameMin, autoBinFromMaxLevels, maxLevels, binTicks, smoothBins, maxHVN, maxLVN, minNodeDistanceTicks, hVNMinPctOfPOC, lVNMaxPctOfPOC, drawPOC, drawHVN, drawLVN, pOCBrush, hVNBrush, lVNBrush, lineWidth, lVNDash);
         }
 
-        public avp avp(ISeries<double> input, global::NinjaTrader.NinjaScript.Indicators.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
+        public avp avp(ISeries<double> input, global::NinjaTrader.NinjaScript.Indicators.avp.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
         {
             if (cacheavp != null)
                 for (int idx = 0; idx < cacheavp.Length; idx++)
@@ -914,12 +913,12 @@ namespace NinjaTrader.NinjaScript.MarketAnalyzerColumns
 {
     public partial class MarketAnalyzerColumn : MarketAnalyzerColumnBase
     {
-        public Indicators.avp avp(global::NinjaTrader.NinjaScript.Indicators.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
+        public Indicators.avp avp(global::NinjaTrader.NinjaScript.Indicators.avp.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
         {
             return indicator.avp(Input, mode, windowMinutes, volumetricTimeFrameMin, autoBinFromMaxLevels, maxLevels, binTicks, smoothBins, maxHVN, maxLVN, minNodeDistanceTicks, hVNMinPctOfPOC, lVNMaxPctOfPOC, drawPOC, drawHVN, drawLVN, pOCBrush, hVNBrush, lVNBrush, lineWidth, lVNDash);
         }
 
-        public Indicators.avp avp(ISeries<double> input, global::NinjaTrader.NinjaScript.Indicators.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
+        public Indicators.avp avp(ISeries<double> input, global::NinjaTrader.NinjaScript.Indicators.avp.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
         {
             return indicator.avp(input, mode, windowMinutes, volumetricTimeFrameMin, autoBinFromMaxLevels, maxLevels, binTicks, smoothBins, maxHVN, maxLVN, minNodeDistanceTicks, hVNMinPctOfPOC, lVNMaxPctOfPOC, drawPOC, drawHVN, drawLVN, pOCBrush, hVNBrush, lVNBrush, lineWidth, lVNDash);
         }
@@ -930,12 +929,12 @@ namespace NinjaTrader.NinjaScript.Strategies
 {
     public partial class Strategy : NinjaTrader.Gui.NinjaScript.StrategyRenderBase
     {
-        public Indicators.avp avp(global::NinjaTrader.NinjaScript.Indicators.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
+        public Indicators.avp avp(global::NinjaTrader.NinjaScript.Indicators.avp.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
         {
             return indicator.avp(Input, mode, windowMinutes, volumetricTimeFrameMin, autoBinFromMaxLevels, maxLevels, binTicks, smoothBins, maxHVN, maxLVN, minNodeDistanceTicks, hVNMinPctOfPOC, lVNMaxPctOfPOC, drawPOC, drawHVN, drawLVN, pOCBrush, hVNBrush, lVNBrush, lineWidth, lVNDash);
         }
 
-        public Indicators.avp avp(ISeries<double> input, global::NinjaTrader.NinjaScript.Indicators.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
+        public Indicators.avp avp(ISeries<double> input, global::NinjaTrader.NinjaScript.Indicators.avp.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
         {
             return indicator.avp(input, mode, windowMinutes, volumetricTimeFrameMin, autoBinFromMaxLevels, maxLevels, binTicks, smoothBins, maxHVN, maxLVN, minNodeDistanceTicks, hVNMinPctOfPOC, lVNMaxPctOfPOC, drawPOC, drawHVN, drawLVN, pOCBrush, hVNBrush, lVNBrush, lineWidth, lVNDash);
         }

--- a/aaa/avp
+++ b/aaa/avp
@@ -850,12 +850,12 @@ namespace NinjaTrader.NinjaScript.Indicators
     {
         private avp[] cacheavp;
 
-        public avp avp(ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
+        public avp avp(global::NinjaTrader.NinjaScript.Indicators.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
         {
             return avp(Input, mode, windowMinutes, volumetricTimeFrameMin, autoBinFromMaxLevels, maxLevels, binTicks, smoothBins, maxHVN, maxLVN, minNodeDistanceTicks, hVNMinPctOfPOC, lVNMaxPctOfPOC, drawPOC, drawHVN, drawLVN, pOCBrush, hVNBrush, lVNBrush, lineWidth, lVNDash);
         }
 
-        public avp avp(ISeries<double> input, ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
+        public avp avp(ISeries<double> input, global::NinjaTrader.NinjaScript.Indicators.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
         {
             if (cacheavp != null)
                 for (int idx = 0; idx < cacheavp.Length; idx++)
@@ -914,12 +914,12 @@ namespace NinjaTrader.NinjaScript.MarketAnalyzerColumns
 {
     public partial class MarketAnalyzerColumn : MarketAnalyzerColumnBase
     {
-        public Indicators.avp avp(Indicators.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
+        public Indicators.avp avp(global::NinjaTrader.NinjaScript.Indicators.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
         {
             return indicator.avp(Input, mode, windowMinutes, volumetricTimeFrameMin, autoBinFromMaxLevels, maxLevels, binTicks, smoothBins, maxHVN, maxLVN, minNodeDistanceTicks, hVNMinPctOfPOC, lVNMaxPctOfPOC, drawPOC, drawHVN, drawLVN, pOCBrush, hVNBrush, lVNBrush, lineWidth, lVNDash);
         }
 
-        public Indicators.avp avp(ISeries<double> input, Indicators.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
+        public Indicators.avp avp(ISeries<double> input, global::NinjaTrader.NinjaScript.Indicators.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
         {
             return indicator.avp(input, mode, windowMinutes, volumetricTimeFrameMin, autoBinFromMaxLevels, maxLevels, binTicks, smoothBins, maxHVN, maxLVN, minNodeDistanceTicks, hVNMinPctOfPOC, lVNMaxPctOfPOC, drawPOC, drawHVN, drawLVN, pOCBrush, hVNBrush, lVNBrush, lineWidth, lVNDash);
         }
@@ -930,12 +930,12 @@ namespace NinjaTrader.NinjaScript.Strategies
 {
     public partial class Strategy : NinjaTrader.Gui.NinjaScript.StrategyRenderBase
     {
-        public Indicators.avp avp(Indicators.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
+        public Indicators.avp avp(global::NinjaTrader.NinjaScript.Indicators.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
         {
             return indicator.avp(Input, mode, windowMinutes, volumetricTimeFrameMin, autoBinFromMaxLevels, maxLevels, binTicks, smoothBins, maxHVN, maxLVN, minNodeDistanceTicks, hVNMinPctOfPOC, lVNMaxPctOfPOC, drawPOC, drawHVN, drawLVN, pOCBrush, hVNBrush, lVNBrush, lineWidth, lVNDash);
         }
 
-        public Indicators.avp avp(ISeries<double> input, Indicators.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
+        public Indicators.avp avp(ISeries<double> input, global::NinjaTrader.NinjaScript.Indicators.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
         {
             return indicator.avp(input, mode, windowMinutes, volumetricTimeFrameMin, autoBinFromMaxLevels, maxLevels, binTicks, smoothBins, maxHVN, maxLVN, minNodeDistanceTicks, hVNMinPctOfPOC, lVNMaxPctOfPOC, drawPOC, drawHVN, drawLVN, pOCBrush, hVNBrush, lVNBrush, lineWidth, lVNDash);
         }

--- a/aaa/avp
+++ b/aaa/avp
@@ -31,17 +31,18 @@ using NinjaTrader.NinjaScript.DrawingTools;
 
 namespace NinjaTrader.NinjaScript.Indicators
 {
+    // ---------------------------
+    // Tipos
+    // ---------------------------
+    public enum ProfileMode
+    {
+        RollingMinutes = 0,
+        Session        = 1,
+        Weekly         = 2
+    }
+
     public class avp : Indicator
     {
-        // ---------------------------
-        // Tipos
-        // ---------------------------
-        public enum ProfileMode
-        {
-            RollingMinutes = 0,
-            Session        = 1,
-            Weekly         = 2
-        }
 
         private class BarContribution
         {
@@ -363,7 +364,7 @@ namespace NinjaTrader.NinjaScript.Indicators
         // ---------------------------
         private void AddClosedBarToProfile(int barIndex, DateTime barTime)
         {
-            if (barIndex < 0 || barIndex >= volBarsType.Volumes.Count)
+            if (barIndex < 0 || barIndex >= volBarsType.Volumes.Count())
                 return;
 
             double lo = Lows[volBip][0];
@@ -849,12 +850,12 @@ namespace NinjaTrader.NinjaScript.Indicators
     {
         private avp[] cacheavp;
 
-        public avp avp(avp.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
+        public avp avp(ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
         {
             return avp(Input, mode, windowMinutes, volumetricTimeFrameMin, autoBinFromMaxLevels, maxLevels, binTicks, smoothBins, maxHVN, maxLVN, minNodeDistanceTicks, hVNMinPctOfPOC, lVNMaxPctOfPOC, drawPOC, drawHVN, drawLVN, pOCBrush, hVNBrush, lVNBrush, lineWidth, lVNDash);
         }
 
-        public avp avp(ISeries<double> input, avp.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
+        public avp avp(ISeries<double> input, ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
         {
             if (cacheavp != null)
                 for (int idx = 0; idx < cacheavp.Length; idx++)
@@ -913,12 +914,12 @@ namespace NinjaTrader.NinjaScript.MarketAnalyzerColumns
 {
     public partial class MarketAnalyzerColumn : MarketAnalyzerColumnBase
     {
-        public Indicators.avp avp(Indicators.avp.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
+        public Indicators.avp avp(Indicators.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
         {
             return indicator.avp(Input, mode, windowMinutes, volumetricTimeFrameMin, autoBinFromMaxLevels, maxLevels, binTicks, smoothBins, maxHVN, maxLVN, minNodeDistanceTicks, hVNMinPctOfPOC, lVNMaxPctOfPOC, drawPOC, drawHVN, drawLVN, pOCBrush, hVNBrush, lVNBrush, lineWidth, lVNDash);
         }
 
-        public Indicators.avp avp(ISeries<double> input, Indicators.avp.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
+        public Indicators.avp avp(ISeries<double> input, Indicators.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
         {
             return indicator.avp(input, mode, windowMinutes, volumetricTimeFrameMin, autoBinFromMaxLevels, maxLevels, binTicks, smoothBins, maxHVN, maxLVN, minNodeDistanceTicks, hVNMinPctOfPOC, lVNMaxPctOfPOC, drawPOC, drawHVN, drawLVN, pOCBrush, hVNBrush, lVNBrush, lineWidth, lVNDash);
         }
@@ -929,12 +930,12 @@ namespace NinjaTrader.NinjaScript.Strategies
 {
     public partial class Strategy : NinjaTrader.Gui.NinjaScript.StrategyRenderBase
     {
-        public Indicators.avp avp(Indicators.avp.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
+        public Indicators.avp avp(Indicators.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
         {
             return indicator.avp(Input, mode, windowMinutes, volumetricTimeFrameMin, autoBinFromMaxLevels, maxLevels, binTicks, smoothBins, maxHVN, maxLVN, minNodeDistanceTicks, hVNMinPctOfPOC, lVNMaxPctOfPOC, drawPOC, drawHVN, drawLVN, pOCBrush, hVNBrush, lVNBrush, lineWidth, lVNDash);
         }
 
-        public Indicators.avp avp(ISeries<double> input, Indicators.avp.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
+        public Indicators.avp avp(ISeries<double> input, Indicators.ProfileMode mode, int windowMinutes, int volumetricTimeFrameMin, bool autoBinFromMaxLevels, int maxLevels, int binTicks, int smoothBins, int maxHVN, int maxLVN, int minNodeDistanceTicks, double hVNMinPctOfPOC, double lVNMaxPctOfPOC, bool drawPOC, bool drawHVN, bool drawLVN, Brush pOCBrush, Brush hVNBrush, Brush lVNBrush, int lineWidth, DashStyleHelper lVNDash)
         {
             return indicator.avp(input, mode, windowMinutes, volumetricTimeFrameMin, autoBinFromMaxLevels, maxLevels, binTicks, smoothBins, maxHVN, maxLVN, minNodeDistanceTicks, hVNMinPctOfPOC, lVNMaxPctOfPOC, drawPOC, drawHVN, drawLVN, pOCBrush, hVNBrush, lVNBrush, lineWidth, lVNDash);
         }
@@ -942,4 +943,3 @@ namespace NinjaTrader.NinjaScript.Strategies
 }
 
 #endregion
-


### PR DESCRIPTION
### Motivation
- Remove type reference issues where `ProfileMode` was nested inside `avp` causing generated signatures to reference a missing type.
- Prevent an indexing error when accessing volumetric bar volumes by ensuring the `Volumes` collection size is checked correctly.

### Description
- Moved the `ProfileMode` enum out of the `avp` class into the `NinjaTrader.NinjaScript.Indicators` namespace so it is visible to generated code and other classes.
- Updated the generated indicator/market analyzer/strategy method signatures to use the correct `ProfileMode` type references (e.g. `ProfileMode` / `Indicators.ProfileMode`) instead of `avp.ProfileMode`.
- Fixed the volumetric bounds check from `volBarsType.Volumes.Count` to `volBarsType.Volumes.Count()` to correctly evaluate the collection length.
- Minor reformatting around the enum placement to keep code structure clear.

### Testing
- No automated tests were executed against the modified code.
- Static checks: quick repository inspections (search and file listing) were used to verify updated type references were applied across generated blocks.
- Manual build or runtime tests were not run in this change set.
- No test failures reported because tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951ccb697ec832c9bb064c0993157c4)